### PR TITLE
Fixing #9, #10, and #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ node_modules
 *.log
 subscription.json
 config.yml
+
+artifacts

--- a/.jscsrc
+++ b/.jscsrc
@@ -9,5 +9,8 @@
         "beforeOpeningCurlyBrace": true,
         "beforeOpeningRoundBrace": true
     },
-    "maximumLineLength": 120
+    "maximumLineLength": 120,
+    "excludeFiles": [
+        "artifacts/**"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -17,33 +17,37 @@ This project was spawned by the desire to [control SmartThings from within Home 
 Events about a device (power, level, switch) are sent to MQTT using the following format:
 
 ```
-/smartthings/{DEVICE_NAME}/${ATTRIBUTE}
+{PREFACE}/{DEVICE_NAME}/${ATTRIBUTE}
 ```
+__PREFACE is defined as "smartthings" by default in your configuration__
 
 For example, my Dimmer Z-Wave Lamp is called "Fireplace Lights" in SmartThings.  The following topics are published:
 
 ```
 # Brightness (0-99)
-/smartthings/Fireplace Lights/level
+smartthings/Fireplace Lights/level
 # Switch State (on|off)
-/smartthings/Fireplace Lights/switch
+smartthings/Fireplace Lights/switch
 ```
 
 The Bridge also subscribes to changes in these topics, so that you can update the device via MQTT.
 
 ```
-$ mqtt pub -t '/smartthings/Fireplace Lights/switch'  -m 'off'
+$ mqtt pub -t 'smartthings/Fireplace Lights/switch'  -m 'off'
 # Light goes off in SmartThings
 ```
 
 # Configuration
 
-The bridge has one yaml file for configuration.  Currently we only have one item you can set:
+The bridge has one yaml file for configuration.  Currently we only have two items you can set:
 
 ```
 ---
 mqtt:
-  host: 192.168.1.200
+    # Specify your MQTT Broker's hostname or IP address here
+    host: mqtt
+    # Preface for the topics $PREFACE/$DEVICE_NAME/$PROPERTY
+    preface: smartthings
 ```
 
 We'll be adding additional fields as this service progresses (port, username, password, etc).

--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,5 @@
 mqtt:
     # Specify your MQTT Broker's hostname or IP address here
     host: mqtt
+    # Preface for the topics $PREFACE/$DEVICE_NAME/$PROPERTY
+    preface: smartthings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MQTTBridge",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Bridge between SmartThings and an MQTT broker",
   "main": "server.js",
   "scripts": {
@@ -35,6 +35,7 @@
     "jsonfile": "^2.2.3",
     "mqtt": "^1.7.0",
     "request": "^2.65.0",
+    "semver": "^5.1.0",
     "winston": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Switching default preface to `smartthings` instead of `/smartthings` but leaving backwards compatibility (fixes #10)
- Adding saving of history to disk, to prevent startup spam (partial fix for #9)
- Do not send level if current state is "off" (fixes #9)
- Resubscribe to topics if connection with MQTT is lost (fixes #11)

@jer