### PR TITLE
Quick check and fix + doc incase hub isn't set. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ $ pm2 restart smartthings-mqtt-bridge
     ```
 
 2. Install the [Device Type][dt] on the [Device Handler IDE][ide-dt]
+** Important: make sure you set the Hub in the device settings! it's a non-optional field but we can't work without it. 
+
 3. Configure the Device Type (via the IDE) with the IP Address, Port, and MAC Address of the machine running the Docker container
 4. Install the [Smart App][app] on the [Smart App IDE][ide-app]
 5. Configure the Smart App (via the Native App) with the devices you want to share and the Device Handler you just installed as the bridge

--- a/devicetypes/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/devicetypes/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -78,12 +78,18 @@ def parse(String description) {
 
 // Send message to the Bridge
 def deviceNotification(message) {
+    if (device.hub == null)
+    {
+        log.error "Hub is null, must set the hub in the device settings so we can get local hub IP and port"
+        return
+    }
+    
     log.debug "Sending '${message}' to device"
     setNetworkAddress()
 
     def slurper = new JsonSlurper()
     def parsed = slurper.parseText(message)
-
+    
     if (parsed.path == '/subscribe') {
         parsed.body.callback = device.hub.getDataValue("localIP") + ":" + device.hub.getDataValue("localSrvPortTCP")
     }


### PR DESCRIPTION
When creating a new device from the device handler, the hub field is optional. If you don't set it then we get a null pointer exception and silent fail resulting in no messages making it from ST to the bridge. This confused me for hours!

