### PR TITLE
Fixing bug with sending switch instead of level

### DIFF
--- a/server.js
+++ b/server.js
@@ -259,10 +259,10 @@ function parseMQTTMessage (topic, message) {
     // If sending switch data and there is already a level value, send level instead
     // SmartThings will turn the device on
     if (property === 'switch' && contents === 'on' &&
-        history[topicCommand] !== undefined) {
+        history[getTopicFor(device, 'level', TOPIC_COMMAND)] !== undefined) {
         winston.info('Passing level instead of switch on');
         property = 'level';
-        contents = history[topicCommand];
+        contents = history[getTopicFor(device, 'level', TOPIC_COMMAND)];
     }
 
     request.post({


### PR DESCRIPTION
Looks like I screwed up and accidentally started sending state instead of level.