### PR TITLE
Force integer to setLevel for dimmable lights

### DIFF
--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -640,7 +640,7 @@ def actionColorTemperature(device, attribute, value) {
 }
 
 def actionLevel(device, attribute, value) {
-    device.setLevel(value)
+    device.setLevel(value as int)
 }
 
 def actionConsumable(device, attribute, value) {


### PR DESCRIPTION
This should fix #40

Looks like it works with existing lights (GE and Linear Dimmer Switches) as well as fixes for other dimmables (CreeBulbs)