### PR TITLE
enabling docker hub builds for Raspberry Pi

### DIFF
--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -1,5 +1,7 @@
-FROM hypriot/rpi-node:4
+FROM ma314smith/rpi2-node-qemu:4
 MAINTAINER St. John Johnson <st.john.johnson@gmail.com> and Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>
+
+RUN [ "cross-build-start" ]
 
 # Create our application direcory
 RUN mkdir -p /usr/src/app
@@ -23,3 +25,5 @@ EXPOSE 8080
 
 # Run the service
 CMD [ "npm", "start" ]
+
+RUN [ "cross-build-end" ]


### PR DESCRIPTION
This will allow ARM cross-builds on the docker hub.  See my fork here: https://hub.docker.com/r/ma314smith/smartthings-mqtt-bridge/builds/

Note that this will break the workaround mentioned in issue #43.  I'm not sure how you want to handle that.  Creating an additional dockerfile (Dockerfile-rpi-hub?) would avoid a breaking change to exiting build processes, but might not be the best long term option.

Let me know your thoughts.