### PR TITLE
Supporting optional setStatus command for the music player capability

### DIFF
--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -643,6 +643,11 @@ def actionMusicPlayer(device, attribute, value) {
                 device.unmute()
             }
         break
+        case "status":
+            if (device.getSupportedCommands().any {it.name == "setStatus"}) {
+                device.setStatus(value)
+            }
+        break
     }
 }
 


### PR DESCRIPTION
Hello,
First, thanks for this awesome project. I'm using it to abstract away the SmartThings<->device interface in new devices I'm creating, so I can just create virtual devices and control them via MQTT (which is easier to interface with than sending HTTP requests to a ST Hub).

My current project is a virtual audio device (capability: `musicPlayer`) designed to control [snapcast](https://github.com/badaix/snapcast) clients. Thanks to this project, hooking up mute/unmute and volume controls was simple. However, after some struggling I figured out that there was no way to pass `status` from MQTT back to the ST device. On the surface, this makes sense - status comes from the player itself, so it shouldn't be externally controllable. However, in the case of virtual devices, the actual audio control is happening somewhere else, and the ST device is just a representation of that state. To allow for this, I made a very small modification to the MQTT Bridge SmartApp so that it passes status messages back to the device, only if `setStatus` is declared as a command.

This benefits me because I now have a sensible place to provide online/offline status of each client, but I can see this being useful for anyone implementing a virtual media player wanting to pass status messages (or even play/pause/stop events) to ST devices.

I realize this may be a bit of an off-spec change, so I understand if it's not appropriate for this project. Thanks again!