### PR TITLE
Do not skip duplicate messages if retain: true

### DIFF
--- a/server.js
+++ b/server.js
@@ -264,13 +264,17 @@ function parseMQTTMessage (topic, message) {
 
     if (history[topicWriteState] === contents) {
         history[topicReadState] = contents;
-        winston.info('Skipping duplicate message from: %s = %s', topic, contents);
-        return;
+        if (config.mqtt[RETAIN] !== false) {
+            winston.info('Skipping duplicate message from: %s = %s', topic, contents);
+            return;
+        }
     }
     if (history[topicReadState] === contents) {
         history[topicWriteState] = contents;
-        winston.info('Skipping duplicate message from: %s = %s', topic, contents);
-        return;
+        if (config.mqtt[RETAIN] !== false) {
+            winston.info('Skipping duplicate message from: %s = %s', topic, contents);
+            return;
+        }
     }
     history[topic] = contents;
 


### PR DESCRIPTION
SmartThings occasionally loses sync with HA. If the MQTT bridge retains the history without verifying that the device changed its state, it will refuse to process new command messages from HA because it already believes that the SmartThings device is in that state. This change ignores the MQTT bridge internal state machine when `retain` is `false`.

There may be a better way to do it, but it's currently working for me.