### PR TITLE
When favoring level data over switch data, make sure level is > 0. Fixes #127

### DIFF
--- a/server.js
+++ b/server.js
@@ -281,10 +281,10 @@ function parseMQTTMessage (topic, message) {
         return;
     }
 
-    // If sending switch data and there is already a level value, send level instead
+    // If sending switch data and there is already a nonzero level value, send level instead
     // SmartThings will turn the device on
     if (property === 'switch' && contents === 'on' &&
-        history[topicLevelCommand] !== undefined) {
+        history[topicLevelCommand] > 0) {
         winston.info('Passing level instead of switch on');
         property = 'level';
         contents = history[topicLevelCommand];


### PR DESCRIPTION
In the (ostensibly common) situation that a switch is `off` and its level is `0`, for an "on" command the bridge is setting level to 0, which doesn't turn on the device. This should fix #127.