### PR TITLE
Switch to an officially-maintained Raspberry-Pi compatible Docker image

### DIFF
--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-node:4
+FROM arm32v7/node:6
 MAINTAINER St. John Johnson <st.john.johnson@gmail.com> and Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>
 
 # Create our application direcory


### PR DESCRIPTION
This PR switches the Raspberry Pi dockerfile's base image to the [official node.js](https://github.com/nodejs/docker-node) image for node 6. The hypriot images are [deprecated](https://hub.docker.com/r/hypriot/rpi-node/):

> DEPRECATION NOTICE
> Use the 'official' Node.js images at https://hub.docker.com/r/arm32v7/node/ instead for Raspberry Pi 2 and 3.

I've been running this version for a few days now with no errors or issues.

**N.B:** I'm not sure if the hypriot image supported the Raspberry Pi 1, but this new base image does not. So if this project needs to support RPi 1, this should not be merged.