### PR TITLE
Fix #133: Deduplication logic too aggressive

### DIFF
--- a/server.js
+++ b/server.js
@@ -262,15 +262,12 @@ function parseMQTTMessage (topic, message) {
         topicSwitchState = getTopicFor(device, 'switch', TOPIC_READ_STATE),
         topicLevelCommand = getTopicFor(device, 'level', TOPIC_COMMAND);
 
-    if (history[topicWriteState] === contents) {
-        history[topicReadState] = contents;
-        winston.info('Skipping duplicate message from: %s = %s', topic, contents);
-        return;
-    }
-    if (history[topicReadState] === contents) {
-        history[topicWriteState] = contents;
-        winston.info('Skipping duplicate message from: %s = %s', topic, contents);
-        return;
+    // Deduplicate only if the incoming message topic is the same as the read state topic
+    if (topic === topicReadState) {
+        if (history[topic] === contents) {
+            winston.info('Skipping duplicate message from: %s = %s', topic, contents);
+            return;
+        }
     }
     history[topic] = contents;
 


### PR DESCRIPTION
Here's an attempt at fixing #133.

We don't want to deduplicate any message that we know is from the user. The only time we don't know for sure that a message is from the user is when it comes from a topic the bridge writes to (i.e. a read topic). The user might also write to a read topic if they haven't set a separate `write` or `command` topic.

This PR simply checks to see if the incoming message is from the read topic, and if so, it deduplicates.