### PR TITLE
Added "sceneSwitch" to capability list

### DIFF
--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -228,6 +228,7 @@ import groovy.transform.Field
         capability: "capability.switch",
         attributes: [
             "scene"
+        ]
     ],
     "shockSensor": [
         name: "Shock Sensor",

--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -223,6 +223,12 @@ import groovy.transform.Field
         ],
         action: "actionOnOff"
     ],
+    "sceneSwitch": [
+        name: "Scene Switch",
+        capability: "capability.switch",
+        attributes: [
+            "scene"
+    ],
     "shockSensor": [
         name: "Shock Sensor",
         capability: "capability.shockSensor",


### PR DESCRIPTION
sceneSwitch will pass the scene attribute that Fibaro switches use to manage additional buttons. For example S2 button on FGD-212 dimmer switches.