### PR TITLE
Use alpine image and update npm packages for x64 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 
 # Copy and install dependencies
 COPY package.json /usr/src/app/
-RUN npm audit fix && npm install --production
+RUN npm i --package-lock-only && npm audit fix --force &&  npm install --production
 
 # Copy everything else
 COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4
+FROM node:alpine
 MAINTAINER St. John Johnson <st.john.johnson@gmail.com> and Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>
 
 # Create our application direcory

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 
 # Copy and install dependencies
 COPY package.json /usr/src/app/
-RUN npm i --package-lock-only && npm audit fix --force &&  npm install --production
+RUN npm install --production
 
 # Copy everything else
 COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 
 # Copy and install dependencies
 COPY package.json /usr/src/app/
-RUN npm install --production
+RUN npm audit fix && npm install --production
 
 # Copy everything else
 COPY . /usr/src/app

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "body-parser": "^1.14.1",
     "express": "^4.13.3",
     "express-joi-validator": "^2.0.0",
-    "express-winston": "^1.2.0",
-    "joi": "^6.10.0",
+    "express-winston": "^2.5.0",
+    "joi": "^13.4.0",
     "js-yaml": "^3.4.3",
     "jsonfile": "^2.2.3",
     "mqtt": "^1.7.0",
@@ -43,8 +43,8 @@
     "winston": "^2.0.0"
   },
   "devDependencies": {
-    "jenkins-mocha": "^2.5.0",
-    "jscs": "^2.9.0",
+    "jenkins-mocha": "^6.0.0",
+    "jscs": "^3.0.7",
     "jshint": "^2.9.1"
   }
 }


### PR DESCRIPTION
Without jumping into the code, switched the image to the `node:alpine` image, added npm package update via npm audit.

Current
```
found 16 vulnerabilities (8 low, 5 moderate, 2 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```
Updated
```
fixed 12 of 16 vulnerabilities in 1100 scanned packages
  4 vulnerabilities required manual review and could not be updated
  4 package updates for 12 vulns involved breaking changes
  (installed due to `--force` option)
npm WARN express-joi-validator@2.0.0 requires a peer of joi@6.x.x but none is installed. You must install peer dependencies yourself.

audited 2923 packages in 5.62s
found 7 vulnerabilities (4 low, 3 moderate)
```

Image size
688MB -> 143MB

Tested image on local instance
