### PR TITLE
Added Switch on/off for Level Capability

### DIFF
--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -146,7 +146,8 @@ import groovy.transform.Field
         name: "Switch Level",
         capability: "capability.switchLevel",
         attributes: [
-            "level"
+            "level",
+            "switch"
         ],
         action: "actionLevel"
     ],
@@ -657,7 +658,18 @@ def actionColorTemperature(device, attribute, value) {
 }
 
 def actionLevel(device, attribute, value) {
-    device.setLevel(value as int)
+    switch(attribute) {
+        case "level":
+            device.setLevel(value as int)
+        break
+        case "switch":
+            if (value == "off") {
+                device.off()
+            } else if (value == "on") {
+                device.on()
+            }
+        break
+    }
 }
 
 def actionPresence(device, attribute, value) {


### PR DESCRIPTION
Using Home Assistant and sending just the level integer is not enough to
turn on my bulbs with level capability. Had to add the switch attribute
as well to be sent/received via MQTT. Thanks so much for this amazing
tool @stjohnjohnson!!!