### PR TITLE
Feature - add generic command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ $ mqtt pub -t 'smartthings/Fireplace Lights/switch'  -m 'off'
 # Light goes off in SmartThings
 ```
 
+A special command can also be sent (by using a different suffix e.g. set_state). The Bridge will subscribe to changes 
+in topics ending in set_state for all devices. Updates to these topics triggers a setStatus command on the device, 
+the device handler has to support this command: 
+
+```
+command "setStatus"
+
+...
+
+def setStatus(type, status) {
+    log.trace("Setting status ${type}: ${status}")
+
+    sendEvent(name: type, value: status)
+}
+```
+
+```
+$ mqtt pub -t 'smartthings/Living Room Temperature/temperature/set_state'  -m '72'
+# Virtual temperature sensor is updated to reflect the new temperature
+```
+
 # Configuration
 
 The bridge has one yaml file for configuration:
@@ -46,7 +67,7 @@ The bridge has one yaml file for configuration:
 ```
 ---
 mqtt:
-    # Specify your MQTT Broker URL here
+    # Specify your MQTT Broker's hostname or IP address here
     host: mqtt://localhost
     # Example from CloudMQTT
     # host: mqtt:///m10.cloudmqtt.com:19427
@@ -65,6 +86,7 @@ mqtt:
     # state_write_suffix: set_state
 
     # Suffix for the command topics $PREFACE/$DEVICE_NAME/$PROPERTY/$COMMAND_SUFFIX
+    # your physical device or application should write to this topic to execute commands in SmartThings devices that support them
     # command_suffix: cmd
 
     # Other optional settings from https://www.npmjs.com/package/mqtt#mqttclientstreambuilder-options

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,9 @@
 ---
 mqtt:
     # Specify your MQTT Broker's hostname or IP address here
-    host: mqtt
-    # Preface for the topics $PREFACE/$DEVICE_NAME/$PROPERTY
+  host: mqtt://localhost
+
+  # Preface for the topics $PREFACE/$DEVICE_NAME/$PROPERTY
     preface: smartthings
 
     # The write and read suffixes need to be different to be able to differentiate when state comes from SmartThings or when its coming from the physical device/application
@@ -16,11 +17,15 @@ mqtt:
     # state_write_suffix: set_state
 
     # Suffix for the command topics $PREFACE/$DEVICE_NAME/$PROPERTY/$COMMAND_SUFFIX
+  # your physical device or application should write to this topic to execute commands in SmartThings devices that support them
     # command_suffix: cmd
 
     # Other optional settings from https://www.npmjs.com/package/mqtt#mqttclientstreambuilder-options
     # username: AzureDiamond
     # password: hunter2
+
+  # MQTT retains state changes be default, retain mode can be disabled:
+  # retain: false
 
 # Port number to listen on
 port: 8080

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 ---
 mqtt:
     # Specify your MQTT Broker's hostname or IP address here
-  host: mqtt://localhost
+    host: mqtt://localhost
 
-  # Preface for the topics $PREFACE/$DEVICE_NAME/$PROPERTY
+    # Preface for the topics $PREFACE/$DEVICE_NAME/$PROPERTY
     preface: smartthings
 
     # The write and read suffixes need to be different to be able to differentiate when state comes from SmartThings or when its coming from the physical device/application
@@ -17,15 +17,15 @@ mqtt:
     # state_write_suffix: set_state
 
     # Suffix for the command topics $PREFACE/$DEVICE_NAME/$PROPERTY/$COMMAND_SUFFIX
-  # your physical device or application should write to this topic to execute commands in SmartThings devices that support them
+    # your physical device or application should write to this topic to execute commands in SmartThings devices that support them
     # command_suffix: cmd
 
     # Other optional settings from https://www.npmjs.com/package/mqtt#mqttclientstreambuilder-options
     # username: AzureDiamond
     # password: hunter2
 
-  # MQTT retains state changes be default, retain mode can be disabled:
-  # retain: false
+    # MQTT retains state changes be default, retain mode can be disabled:
+    # retain: false
 
 # Port number to listen on
 port: 8080

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartthings-mqtt-bridge",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Bridge between SmartThings and an MQTT broker",
   "main": "server.js",
   "bin": {

--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -29,13 +29,13 @@ import groovy.transform.Field
             "acceleration"
         ]
     ],
-	"airQualitySensors": [
-		name: "AirQuality Sensor",
-		capability: "capability.airQualitySensor",
-		attributes: [
-			"airQuality"
-		]
-	],
+    "airQualitySensors": [
+        name: "AirQuality Sensor",
+        capability: "capability.airQualitySensor",
+        attributes: [
+            "airQuality"
+        ]
+    ],
     "alarm": [
         name: "Alarm",
         capability: "capability.alarm",
@@ -120,14 +120,14 @@ import groovy.transform.Field
         ],
         action: "actionOpenClosed"
     ],
-	"dustSensors": [
-		name: "Dust Sensor",
-		capability: "capability.dustSensor",
-		attributes: [
-			"fineDustLevel",
-			"dustLevel"
-		]
-	],
+    "dustSensors": [
+        name: "Dust Sensor",
+        capability: "capability.dustSensor",
+        attributes: [
+            "fineDustLevel",
+            "dustLevel"
+        ]
+    ],
     "energyMeter": [
         name: "Energy Meter",
         capability: "capability.energyMeter",
@@ -228,7 +228,8 @@ import groovy.transform.Field
         capability: "capability.relativeHumidityMeasurement",
         attributes: [
             "humidity"
-        ]
+        ],
+        action: "actionHumiditySensors"
     ],
     "relaySwitch": [
         name: "Relay Switch",
@@ -316,7 +317,8 @@ import groovy.transform.Field
         capability: "capability.temperatureMeasurement",
         attributes: [
             "temperature"
-        ]
+        ],
+        action: "actionTemperatureSensors"
     ],
     "thermostat": [
         name: "Thermostat",
@@ -561,7 +563,7 @@ def bridgeHandler(evt) {
                             state.ignoreEvent = json;
                         }
                         else {
-                        	log.debug "Device doesn't support setStatus command."
+                            log.debug "Device doesn't support setStatus command."
                         }
                     }
                     else {
@@ -572,10 +574,10 @@ def bridgeHandler(evt) {
                         }
                         else if (device.getSupportedCommands().any {it.name == json.type}) {
                             log.debug "Calling device command ${json.type} with ${json.value}"
-                        	device."$json.type"(json.value)
+                            device."$json.type"(json.value)
                         }
                         else {
-                        	log.debug "Device doesn't support ${json.type} command."
+                            log.debug "Device doesn't support ${json.type} command."
                         }
                     }
                 }
@@ -715,16 +717,36 @@ def actionColorTemperature(device, attribute, value) {
     device.setColorTemperature(value as int)
 }
 
+//Temperature Sensors don't have commands but a simulated sensor might hence the hasCommand() check.
+def actionTemperatureSensors(device, attribute, value) {
+    if (device.hasCommand("temperature")) {
+        device.temperature(value as int)
+    }
+    if (device.hasCommand("setTemperature")) {
+        device.setTemperature(value as int)
+    }
+}
+
+//Humidity Sensors don't have commands but a simulated sensor might hence the hasCommand() check.
+def actionHumiditySensors(device, attribute, value) {
+    if (device.hasCommand("humidity")) {
+        device.humidity(value as int)
+    }
+    if (device.hasCommand("setHumidity")) {
+        device.setHumidity(value as int)
+    }
+}
+
 def actionLevel(device, attribute, value) {
     device.setLevel(value as int)
 }
 
 def actionPresence(device, attribute, value) {
     if (value == "present") {
-    	device.arrived();
+        device.arrived();
     }
     else if (value == "not present") {
-    	device.departed();
+        device.departed();
     }
 }
 

--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -560,12 +560,22 @@ def bridgeHandler(evt) {
                             device.setStatus(json.type, json.value)
                             state.ignoreEvent = json;
                         }
+                        else {
+                        	log.debug "Device doesn't support setStatus command."
+                        }
                     }
                     else {
                         if (capability.containsKey("action")) {
                             def action = capability["action"]
                             // Yes, this is calling the method dynamically
                             "$action"(device, json.type, json.value)
+                        }
+                        else if (device.getSupportedCommands().any {it.name == json.type}) {
+                            log.debug "Calling device command ${json.type} with ${json.value}"
+                        	device."$json.type"(json.value)
+                        }
+                        else {
+                        	log.debug "Device doesn't support ${json.type} command."
                         }
                     }
                 }


### PR DESCRIPTION
My main change is line 575 of the smart app. It checks if the device supports the command being sent and calls it directly even when no action is specified in the capabilities map.

This allows virtual devices that implement commands with the same name as the capability state (e.g. temperature()) to just work. 

For temperature and humidity I did add actions that call temperate or setTemperature depending on which is supported (I have seen both used).

This should help people who are using the virtual sensors from smartthings with this bridge. A better sensor device handler fully compatible with this bridge is available here: https://github.com/gandazgul/mqtt-smartthings-devices/blob/master/devicetypes/gandazgul/mqtt-temperature-sensor.src/mqtt-temperature-sensor.groovy