### PR TITLE
Added Temperature, Humidity & Contact Sensor Post/Call Back to SmartThings

### DIFF
--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -755,7 +755,7 @@ def actionTemperatureSensors(device, attribute, value) {
         device.temperature(value as int)
     }
     if (device.hasCommand("setTemperature")) {
-        device.setTemperature(value as int)
+        device.setTemperature(value)
     }
 }
 

--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -110,7 +110,8 @@ import groovy.transform.Field
         capability: "capability.contactSensor",
         attributes: [
             "contact"
-        ]
+        ],
+        action: "actionOpenClosed"
     ],
     "doorControl": [
         name: "Door Control",

--- a/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
+++ b/smartapps/stj/mqtt-bridge.src/mqtt-bridge.groovy
@@ -228,7 +228,8 @@ import groovy.transform.Field
         capability: "capability.relativeHumidityMeasurement",
         attributes: [
             "humidity"
-        ]
+        ],
+        action: "actionHumiditySensors"
     ],
     "relaySwitch": [
         name: "Relay Switch",
@@ -316,7 +317,8 @@ import groovy.transform.Field
         capability: "capability.temperatureMeasurement",
         attributes: [
             "temperature"
-        ]
+        ],
+        action: "actionTemperatureSensors"
     ],
     "thermostat": [
         name: "Thermostat",
@@ -744,6 +746,26 @@ def actionHeatingThermostat(device, attribute, value) {
 
 def actionThermostatMode(device, attribute, value) {
     device.setThermostatMode(value)
+}
+
+//Temperature Sensors don't have commands but a simulated sensor might hence the hasCommand() check.
+def actionTemperatureSensors(device, attribute, value) {
+    if (device.hasCommand("temperature")) {
+        device.temperature(value as int)
+    }
+    if (device.hasCommand("setTemperature")) {
+        device.setTemperature(value as int)
+    }
+}
+
+//Humidity Sensors don't have commands but a simulated sensor might hence the hasCommand() check.
+def actionHumiditySensors(device, attribute, value) {
+    if (device.hasCommand("humidity")) {
+        device.humidity(value as int)
+    }
+    if (device.hasCommand("setHumidity")) {
+        device.setHumidity(value as int)
+    }
 }
 
 def actionTimedSession(device, attribute, value) {


### PR DESCRIPTION
I added Temperature, Humidity & Contact Sensor Post Back to SmartThings. Otherwise I had to use lame workarounds (like syncing with a switch). Modifying the SmartApp was so much simpler than any other solution. 10 lines of code but world of difference with these 3 capabilities and their read-only limitations in SmartThings.

Ultimately, being able to post these back to ST were big missing pieces for me. @stjohnjohnson I'd appreciate my enhancement pull becoming part of your release and respect your work very much! As an FYI, most of my code is a subset of pull #194 + a few more lines. However, the pull is just more narrow is scope and thus less code to verify. @gandazgul thanks for that pull.